### PR TITLE
Get meteor to include components referenced in Aurelia view templates

### DIFF
--- a/package.js
+++ b/package.js
@@ -33,6 +33,7 @@ Package.registerBuildPlugin({
     'ecmascript@0.1.6',
     'caching-compiler@1.0.0',
     'html-tools@1.0.5',
+    'underscore@1.0.4',
   ],
   sources: [
     'plugin/html-compiler.js',

--- a/plugin/html-compiler.js
+++ b/plugin/html-compiler.js
@@ -37,18 +37,36 @@ class HTMLCompiler extends CachingCompiler {
     moduleName = packageName ? packageName + '/' + moduleName : moduleName;
     const src = inputFile.getContentsAsString()
     // Just parse the html to make sure it is correct before minifying
+    let fragment;
     try {
-      HTMLTools.parseFragment(src)
+      fragment = HTMLTools.parseFragment(src);
     } catch (err) {
       return inputFile.error({
         message: "HTML syntax error: " + err.message,
         sourcePath: inputFile.getPathInPackage(),
       });
     }
+    const requiredModules = this.extractRequiredModules(fragment);
     return {
-      code: this.buildTemplate(src, moduleName),
+      code: this.buildTemplate(src, moduleName, requiredModules),
       path: fileName + '.js',
     };
+  }
+
+  extractRequiredModules(fragment) {
+    const results = [];
+    const process = children => {
+      _.each(children, (child) => {
+        if (child.tagName && child.tagName === 'require') {
+          results.push(child.attrs.from);
+        }
+        if (Object.prototype.toString.call(child.children) === '[object Array]') {
+          process(child.children);
+        }
+      });
+    };
+    process(fragment);
+    return results;
   }
 
   addCompileResult(inputFile, compileResult) {
@@ -60,8 +78,9 @@ class HTMLCompiler extends CachingCompiler {
     });
   }
 
-  buildTemplate(src, moduleName) {
-    return `module.exports = "${this.clean(src)}";`;
+  buildTemplate(src, moduleName, requiredModules) {
+    return _(requiredModules).map(x => `require("${x}");`).join('\n') +
+      `\nmodule.exports = "${this.clean(src)}";`;
   }
 
   clean(src) {


### PR DESCRIPTION
I'm using the imports folder in meteor 1.3 and meteor doesn't automatically bundle up components referenced in Aurelia view using the <require from='...'> element. To work around this you can duplicate the reference by adding import statements to the top of the view model file but it's a pain.

This change looks for all <require from='...'> elements and outputs require('...'); calls in the generated js, so meteor then sends the referenced component files.

You might not want to include this in your package since it's very specific to Aurelia views.

I've only tested this with meteor 1.3, it might break on previous versions.

There may be a better way to do this, this is just the first thing that came to mind.
