### PR TITLE
Fix empty html parse

### DIFF
--- a/plugin/html-compiler.js
+++ b/plugin/html-compiler.js
@@ -57,6 +57,9 @@ class HTMLCompiler extends CachingCompiler {
   extractRequiredModules(fragment) {
     const results = [];
     const process = children => {
+			if (children === null || typeof children === 'undefined'){
+				return;
+			}
       children.forEach(child => {
         if (child.tagName && child.tagName === 'require') {
           const fromAttr = child.attrs.from;


### PR DESCRIPTION
Empty html file templates throws errors and this fix adds a verification.
